### PR TITLE
Convert the atmospheric pressure to sea-level pressure value.

### DIFF
--- a/sensor_scripts/current.py
+++ b/sensor_scripts/current.py
@@ -4,11 +4,17 @@ from Adafruit_BME280 import *
 
 sensor = BME280(mode=BME280_OSAMPLE_8)
 
+# Altitude in meters to calculate sea-level pressure
+altitude = 93
+
 try:
     temperature = sensor.read_temperature()
     humidity = sensor.read_humidity()
     pascals = sensor.read_pressure()
     hectopascals = pascals / 100
+    # Adjust pressure to sea level
+    hectopascals = hectopascals*(1-(0.0065 * altitude)/(temperature + 0.0065 * altitude + 273.15))**(-5.257)
+
     print '{0:0.1f}\n{1}\n{2:0.2f}'.format(temperature, int(humidity), hectopascals)
 except RuntimeError as e:
     print 'error\n{0}'.format(e)

--- a/sensor_scripts/logger.py
+++ b/sensor_scripts/logger.py
@@ -3,9 +3,14 @@ import time
 
 sensor = BME280(mode=BME280_OSAMPLE_8)
 
+# Altitude in meters to calculate sea-level pressure
+altitude = 93
+
 degrees = sensor.read_temperature()
 pascals = sensor.read_pressure()
 hectopascals = pascals / 100
+# Adjust pressure to sea level
+hectopascals = hectopascals*(1-(0.0065 * altitude)/(degrees + 0.0065 * altitude + 273.15))**(-5.257)
 humidity = sensor.read_humidity()
 timestamp = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime())
 


### PR DESCRIPTION
There is now a parameter in both current.py and logger.py
script to set the measurements altitude.

Formula from: http://keisan.casio.com/exec/system/1224575267

Without this fix the pressure value was always too low, now it's the same as the ones provided by other measurement systems.
