### PR TITLE
Update BME280 kwargs

### DIFF
--- a/sensor_scripts/current.py
+++ b/sensor_scripts/current.py
@@ -2,7 +2,7 @@
 
 from Adafruit_BME280 import *
 
-sensor = BME280(mode=BME280_OSAMPLE_8)
+sensor = BME280(t_mode=BME280_OSAMPLE_8,p_mode=BME280_OSAMPLE_8,h_mode=BME280_OSAMPLE_8)
 
 # Altitude in meters to calculate sea-level pressure
 altitude = 93


### PR DESCRIPTION
BME280's `__init__` no longer supports "mode" as a keyword arg: https://github.com/adafruit/Adafruit_Python_BME280/commit/31c899c6fb5e76022cd3b004c1220cf4ee203a11